### PR TITLE
internal/credentials: make kubernetes auth service account namespaced

### DIFF
--- a/internal/common/common.go
+++ b/internal/common/common.go
@@ -402,3 +402,17 @@ func NewSyncableSecretMetaData(obj ctrlclient.Object) (*SyncableSecretMetaData, 
 		return nil, fmt.Errorf("unsupported type %T", t)
 	}
 }
+
+// GetKubernetesServiceAccountNamespacedName returns the NamespacedName for the Kubernetes VaultAuth's configured
+// serviceAccount.
+// If the serviceAccount is empty then defaults Namespace and Name will be returned.
+func GetKubernetesServiceAccountNamespacedName(a *secretsv1beta1.VaultAuthConfigKubernetes, providerNamespace string) (types.NamespacedName, error) {
+	if a.ServiceAccount == "" && providerNamespace == "" {
+		return types.NamespacedName{}, fmt.Errorf("provider's default namespace is not set, this is a bug")
+	}
+	saRef, err := parseResourceRef(a.ServiceAccount, providerNamespace)
+	if err != nil {
+		return types.NamespacedName{}, err
+	}
+	return saRef, nil
+}

--- a/internal/credentials/vault/kubernetes.go
+++ b/internal/credentials/vault/kubernetes.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	secretsv1beta1 "github.com/hashicorp/vault-secrets-operator/api/v1beta1"
+	"github.com/hashicorp/vault-secrets-operator/internal/common"
 	"github.com/hashicorp/vault-secrets-operator/internal/helpers"
 )
 
@@ -56,9 +57,13 @@ func (l *KubernetesCredentialProvider) Init(ctx context.Context, client ctrlclie
 }
 
 func (l *KubernetesCredentialProvider) getServiceAccount(ctx context.Context, client ctrlclient.Client) (*corev1.ServiceAccount, error) {
+	a, err := common.GetKubernetesServiceAccountNamespacedName(l.authObj.Spec.Kubernetes, l.providerNamespace)
+	if err != nil {
+		return nil, err
+	}
 	key := ctrlclient.ObjectKey{
-		Namespace: l.providerNamespace,
-		Name:      l.authObj.Spec.Kubernetes.ServiceAccount,
+		Namespace: a.Namespace,
+		Name:      a.Name,
 	}
 	sa := &corev1.ServiceAccount{}
 	if err := client.Get(ctx, key, sa); err != nil {


### PR DESCRIPTION
This commit adds the ability to specify a namespace for the service account used to authenticate to Vault. This is useful when you want to use a service account in a different namespace than the one the secret (vaultStaticSecret, vaultDynamicSecret) is located. This change is backwards compatible, so if no namespace is specified, the service account will be looked up in the same namespace as the secret.

Example: Here the service account that will be used to authenticate to Vault is the service account `default` that it is in the namespace "vault-secrets-operator-system".
```yaml
apiVersion: secrets.hashicorp.com/v1beta1
kind: VaultAuth
metadata:
  name: static-auth
  namespace: app
spec:
  vaultConnectionRef: vault-connection
  allowedNamespaces:
    - "*"
  method: kubernetes
  mount: demo-auth-mount
  kubernetes:
    role: role1
    serviceAccount: vault-secrets-operator-system/default
```

Closes https://github.com/hashicorp/vault-secrets-operator/issues/336